### PR TITLE
Slim down the deployed package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,5 @@
   "readmeFilename": "README.md",
   "gitHead": "15bef0805246629cc89fb71ded29e674009ffc45",
   "dependencies": {
-    "tape": "~2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "description": "@substack's caller.js as a module",
   "main": "index.js",
-  "directories": {
-    "test": "test"
-  },
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "tape test/*.js"
   },


### PR DESCRIPTION
Currently installing as a dependency will cause `npm` to download all the tests and dependencies, which isn't necessary. This should decrease the payload significantly. 